### PR TITLE
feat: Add context-aware gettext functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,45 @@ echo pgettext('verb', 'Post');      // "Veröffentlichen"
 echo pgettext('noun', 'Post');      // "Beitrag"
 ```
 
+### Handling plural forms with context
+
+```php
+// npgettext($context, $singular, $plural, $count)
+
+$count = 3;
+// Insert values with sprintf()
+echo sprintf(npgettext('email', '%d message', '%d messages', intval($count)), $count);
+// Email context: "3 messages"
+
+echo sprintf(npgettext('chat', '%d message', '%d messages', intval($count)), $count);
+// Chat context: "3 chats" or "3 texts"
+
+```
+
+### Translates with both domain and context
+
+```php
+// dpgettext($domain, $context, $message)
+
+// Using different translation domains
+echo dpgettext('admin', 'button', 'Delete');    // "Remove permanently"
+echo dpgettext('frontend', 'button', 'Delete'); // "Move to trash"
+```
+
+### Combines domain, context, and plural handling.
+
+```php
+// dnpgettext($domain, $context, $singular, $plural, $count)
+
+$files = 5;
+// Insert values with sprintf()
+echo sprintf(dnpgettext('filesystem', 'trash', '%d file', '%d files', intval($files)), $files);
+// Result: "5 files in trash"
+
+echo sprintf(dnpgettext('filesystem', 'upload', '%d file', '%d files', intval($files)), $files);
+// Result: "5 files uploaded"
+```
+
 ### Setting Locale and Domain
 
 ```php

--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ echo _('Hello');  // Outputs: Hallo
 echo _('Goodbye');  // Outputs: Auf Wiedersehen
 ```
 
+### Using with context
+
+```php
+service('gettext')->setLocale('de');
+
+echo pgettext('verb', 'Post');      // "Veröffentlichen"
+echo pgettext('noun', 'Post');      // "Beitrag"
+```
+
 ### Setting Locale and Domain
 
 ```php

--- a/src/Gettext.php
+++ b/src/Gettext.php
@@ -35,7 +35,7 @@ class Gettext
             throw GettextException::forDirDoesNotExist();
         }
 
-        if (! in_array($domain, $this->config->allowedDomains, true)) {
+        if (! $this->verifyDomain($domain)) {
             throw GettextException::forDomainNotSupported();
         }
 
@@ -96,6 +96,10 @@ class Gettext
      */
     public function dpgettext(string $domain, string $msgctxt, string $msgid): string
     {
+        if (! $this->verifyDomain($domain)) {
+            throw GettextException::forDomainNotSupported();
+        }
+
         $contextString = $msgctxt . "\x04" . $msgid;
         $translation   = dgettext($domain, $contextString);
 
@@ -115,6 +119,10 @@ class Gettext
      */
     public function dnpgettext(string $domain, string $msgctxt, string $msgid, string $msgidPlural, int $n): string
     {
+        if (! $this->verifyDomain($domain)) {
+            throw GettextException::forDomainNotSupported();
+        }
+
         $contextString       = $msgctxt . "\x04" . $msgid;
         $contextStringPlural = $msgctxt . "\x04" . $msgidPlural;
         $translation         = dngettext($domain, $contextString, $contextStringPlural, $n);
@@ -124,5 +132,17 @@ class Gettext
         }
 
         return $translation;
+    }
+
+    /**
+     * Verify if the domain is allowed
+     *
+     * @param string $domain The text domain to verify
+     *
+     * @return bool True if the domain is allowed, false otherwise
+     */
+    private function verifyDomain(string $domain): bool
+    {
+        return in_array($domain, $this->config->allowedDomains, true);
     }
 }

--- a/src/Gettext.php
+++ b/src/Gettext.php
@@ -59,8 +59,6 @@ class Gettext
         $contextString = $msgctxt . "\x04" . $msgid;
         $translation   = gettext($contextString);
 
-        // If no translation found, gettext returns the input string
-        // In that case, return just the msgid
         return ($translation === $contextString) ? $msgid : $translation;
     }
 
@@ -80,8 +78,6 @@ class Gettext
         $contextStringPlural = $msgctxt . "\x04" . $msgidPlural;
         $translation         = ngettext($contextString, $contextStringPlural, $n);
 
-        // If no translation found, ngettext returns one of the input strings
-        // In that case, return the appropriate form without context
         if ($translation === $contextString || $translation === $contextStringPlural) {
             return ($n === 1) ? $msgid : $msgidPlural;
         }
@@ -103,8 +99,6 @@ class Gettext
         $contextString = $msgctxt . "\x04" . $msgid;
         $translation   = dgettext($domain, $contextString);
 
-        // If no translation found, dgettext returns the input string
-        // In that case, return just the msgid
         return ($translation === $contextString) ? $msgid : $translation;
     }
 
@@ -125,8 +119,6 @@ class Gettext
         $contextStringPlural = $msgctxt . "\x04" . $msgidPlural;
         $translation         = dngettext($domain, $contextString, $contextStringPlural, $n);
 
-        // If no translation found, dngettext returns one of the input strings
-        // In that case, return the appropriate form without context
         if ($translation === $contextString || $translation === $contextStringPlural) {
             return ($n === 1) ? $msgid : $msgidPlural;
         }

--- a/src/Gettext.php
+++ b/src/Gettext.php
@@ -45,4 +45,92 @@ class Gettext
 
         return $this;
     }
+
+    /**
+     * Context-aware gettext
+     *
+     * @param string $msgctxt The message context
+     * @param string $msgid   The message identifier
+     *
+     * @return string The translated string
+     */
+    public function pgettext(string $msgctxt, string $msgid): string
+    {
+        $contextString = $msgctxt . "\x04" . $msgid;
+        $translation   = gettext($contextString);
+
+        // If no translation found, gettext returns the input string
+        // In that case, return just the msgid
+        return ($translation === $contextString) ? $msgid : $translation;
+    }
+
+    /**
+     * Context-aware ngettext (plural)
+     *
+     * @param string $msgctxt     The message context
+     * @param string $msgid       The singular message identifier
+     * @param string $msgidPlural The plural message identifier
+     * @param int    $n           The number for determining plural form
+     *
+     * @return string The translated string
+     */
+    public function npgettext(string $msgctxt, string $msgid, string $msgidPlural, int $n): string
+    {
+        $contextString       = $msgctxt . "\x04" . $msgid;
+        $contextStringPlural = $msgctxt . "\x04" . $msgidPlural;
+        $translation         = ngettext($contextString, $contextStringPlural, $n);
+
+        // If no translation found, ngettext returns one of the input strings
+        // In that case, return the appropriate form without context
+        if ($translation === $contextString || $translation === $contextStringPlural) {
+            return ($n === 1) ? $msgid : $msgidPlural;
+        }
+
+        return $translation;
+    }
+
+    /**
+     * Context-aware dgettext (with domain)
+     *
+     * @param string $domain  The text domain
+     * @param string $msgctxt The message context
+     * @param string $msgid   The message identifier
+     *
+     * @return string The translated string
+     */
+    public function dpgettext(string $domain, string $msgctxt, string $msgid): string
+    {
+        $contextString = $msgctxt . "\x04" . $msgid;
+        $translation   = dgettext($domain, $contextString);
+
+        // If no translation found, dgettext returns the input string
+        // In that case, return just the msgid
+        return ($translation === $contextString) ? $msgid : $translation;
+    }
+
+    /**
+     * Context-aware dngettext (with domain and plural)
+     *
+     * @param string $domain      The text domain
+     * @param string $msgctxt     The message context
+     * @param string $msgid       The singular message identifier
+     * @param string $msgidPlural The plural message identifier
+     * @param int    $n           The number for determining plural form
+     *
+     * @return string The translated string
+     */
+    public function dnpgettext(string $domain, string $msgctxt, string $msgid, string $msgidPlural, int $n): string
+    {
+        $contextString       = $msgctxt . "\x04" . $msgid;
+        $contextStringPlural = $msgctxt . "\x04" . $msgidPlural;
+        $translation         = dngettext($domain, $contextString, $contextStringPlural, $n);
+
+        // If no translation found, dngettext returns one of the input strings
+        // In that case, return the appropriate form without context
+        if ($translation === $contextString || $translation === $contextStringPlural) {
+            return ($n === 1) ? $msgid : $msgidPlural;
+        }
+
+        return $translation;
+    }
 }

--- a/src/Helpers/gettext_helper.php
+++ b/src/Helpers/gettext_helper.php
@@ -3,9 +3,10 @@
 if (! function_exists('pgettext')) {
     /**
      * Context-aware gettext translation
-     * 
+     *
      * @param string $msgctxt The message context
-     * @param string $msgid The message identifier
+     * @param string $msgid   The message identifier
+     *
      * @return string The translated message
      */
     function pgettext(string $msgctxt, string $msgid): string
@@ -17,11 +18,12 @@ if (! function_exists('pgettext')) {
 if (! function_exists('npgettext')) {
     /**
      * Context-aware plural gettext translation
-     * 
-     * @param string $msgctxt The message context
-     * @param string $msgid Singular form
+     *
+     * @param string $msgctxt     The message context
+     * @param string $msgid       Singular form
      * @param string $msgidPlural Plural form
-     * @param int $n The count to determine singular/plural
+     * @param int    $n           The count to determine singular/plural
+     *
      * @return string The translated message
      */
     function npgettext(string $msgctxt, string $msgid, string $msgidPlural, int $n): string
@@ -33,10 +35,11 @@ if (! function_exists('npgettext')) {
 if (! function_exists('dpgettext')) {
     /**
      * Context-aware dgettext (with domain)
-     * 
-     * @param string $domain The text domain
+     *
+     * @param string $domain  The text domain
      * @param string $msgctxt The message context
-     * @param string $msgid The message identifier
+     * @param string $msgid   The message identifier
+     *
      * @return string The translated message
      */
     function dpgettext(string $domain, string $msgctxt, string $msgid): string
@@ -48,12 +51,13 @@ if (! function_exists('dpgettext')) {
 if (! function_exists('dnpgettext')) {
     /**
      * Context-aware dngettext (with domain and plural)
-     * 
-     * @param string $domain The text domain
-     * @param string $msgctxt The message context
-     * @param string $msgid Singular form
+     *
+     * @param string $domain      The text domain
+     * @param string $msgctxt     The message context
+     * @param string $msgid       Singular form
      * @param string $msgidPlural Plural form
-     * @param int $n The count to determine singular/plural
+     * @param int    $n           The count to determine singular/plural
+     *
      * @return string The translated message
      */
     function dnpgettext(string $domain, string $msgctxt, string $msgid, string $msgidPlural, int $n): string

--- a/src/Helpers/gettext_helper.php
+++ b/src/Helpers/gettext_helper.php
@@ -1,0 +1,63 @@
+<?php
+
+if (! function_exists('pgettext')) {
+    /**
+     * Context-aware gettext translation
+     * 
+     * @param string $msgctxt The message context
+     * @param string $msgid The message identifier
+     * @return string The translated message
+     */
+    function pgettext(string $msgctxt, string $msgid): string
+    {
+        return service('gettext')->pgettext($msgctxt, $msgid);
+    }
+}
+
+if (! function_exists('npgettext')) {
+    /**
+     * Context-aware plural gettext translation
+     * 
+     * @param string $msgctxt The message context
+     * @param string $msgid Singular form
+     * @param string $msgidPlural Plural form
+     * @param int $n The count to determine singular/plural
+     * @return string The translated message
+     */
+    function npgettext(string $msgctxt, string $msgid, string $msgidPlural, int $n): string
+    {
+        return service('gettext')->npgettext($msgctxt, $msgid, $msgidPlural, $n);
+    }
+}
+
+if (! function_exists('dpgettext')) {
+    /**
+     * Context-aware dgettext (with domain)
+     * 
+     * @param string $domain The text domain
+     * @param string $msgctxt The message context
+     * @param string $msgid The message identifier
+     * @return string The translated message
+     */
+    function dpgettext(string $domain, string $msgctxt, string $msgid): string
+    {
+        return service('gettext')->dpgettext($domain, $msgctxt, $msgid);
+    }
+}
+
+if (! function_exists('dnpgettext')) {
+    /**
+     * Context-aware dngettext (with domain and plural)
+     * 
+     * @param string $domain The text domain
+     * @param string $msgctxt The message context
+     * @param string $msgid Singular form
+     * @param string $msgidPlural Plural form
+     * @param int $n The count to determine singular/plural
+     * @return string The translated message
+     */
+    function dnpgettext(string $domain, string $msgctxt, string $msgid, string $msgidPlural, int $n): string
+    {
+        return service('gettext')->dnpgettext($domain, $msgctxt, $msgid, $msgidPlural, $n);
+    }
+}

--- a/tests/GettextTest.php
+++ b/tests/GettextTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests;
 
 use CodeIgniter\Test\CIUnitTestCase;


### PR DESCRIPTION
Context-aware gettext functions are not part of the default php-gettext extension. So wouldn't it be nice if this Gettext Class for Codeigniter 4 supports those aswell?

This PR implements the gettext context functions and are used the following way:

Four context-aware gettext functions have been added to handle translations where the same string may have different meanings depending on context:

- **`pgettext()`** - Context-aware gettext
- **`npgettext()`** - Context-aware plural gettext  
- **`dpgettext()`** - Context-aware gettext with domain
- **`dnpgettext()`** - Context-aware plural gettext with domain

## Usage Examples

### `pgettext($context, $message)`

Translates a message within a specific context.
```php
// "lead" can mean different things
echo pgettext('verb', 'lead');      // To lead a team
echo pgettext('noun', 'lead');      // The metal lead
```

### `npgettext($context, $singular, $plural, $count)`

Handles plural forms with context.
```php
$count = 3;
echo npgettext('email', '%d message', '%d messages', $count);
// Email context: "3 messages"

echo npgettext('chat', '%d message', '%d messages', $count);
// Chat context: "3 chats" or "3 texts"
```

### `dpgettext($domain, $context, $message)`

Translates with both domain and context.
```php
// Using different translation domains
echo dpgettext('admin', 'button', 'Delete');    // "Remove permanently"
echo dpgettext('frontend', 'button', 'Delete'); // "Move to trash"
```

### `dnpgettext($domain, $context, $singular, $plural, $count)`

Combines domain, context, and plural handling.
```php
$files = 5;
echo dnpgettext('filesystem', 'trash', '%d file', '%d files', $files);
// Result: "5 files in trash"

echo dnpgettext('filesystem', 'upload', '%d file', '%d files', $files);
// Result: "5 files uploaded"
```

## Why use context?

Context prevents translation conflicts when the same word has different meanings:
```php
// Without context - ambiguous
echo _('Open');  // Open a file? Open status? Open source?

// With context - precise
echo pgettext('verb', 'Open');       // "Open the file"
echo pgettext('adjective', 'Open');  // "Status: Open"
```


**Checklist:**
- [x] Securely signed commits
- [x] Component(s) with PHPDoc blocks, only if necessary or adds value
- [x] Unit testing, with >80% coverage
- [x] User guide updated
- [x] Conforms to style guide
